### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ on:
     branches: [ master ]
 
 name: Deploy Extension
+permissions:
+  contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PedroRodrigues527/auto-logger-vscode-extension/security/code-scanning/1](https://github.com/PedroRodrigues527/auto-logger-vscode-extension/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/main.yml` at the workflow root (top-level), so it applies to all jobs by default. For this workflow, the safest minimal non-breaking permission is:

- `contents: read`

This supports `actions/checkout` while preventing unnecessary write scopes on `GITHUB_TOKEN`. No imports, methods, or dependencies are needed—just YAML configuration in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
